### PR TITLE
Added Slf4j for using logger instant of usual system print

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -183,5 +183,10 @@
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.30</version>
+    </dependency>
   </dependencies>
 </project>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -163,6 +163,11 @@
       <artifactId>commons-cli</artifactId>
       <version>1.9.0</version>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.4.14</version>
+    </dependency>
 
     <!-- external test dependencies -->
     <dependency>

--- a/cli/src/main/java/tools/vitruv/cli/CLI.java
+++ b/cli/src/main/java/tools/vitruv/cli/CLI.java
@@ -17,12 +17,14 @@ import tools.vitruv.cli.options.ReactionOption;
 import tools.vitruv.cli.options.UserInteractorOption;
 import tools.vitruv.cli.options.VitruvCLIOption;
 import tools.vitruv.framework.vsum.VirtualModelBuilder;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * The CLI class is the main entry point for the command line interface of the Vitruv framework. It
  * parses the command line arguments and triggers the generation of the necessary files and the
  * build of the project.
  */
+@Slf4j
 public class CLI {
 
   /**
@@ -53,17 +55,12 @@ public class CLI {
       CommandLine line = parser.parse(options, args);
       VirtualModelBuilder builder = new VirtualModelBuilder();
       for (Option option : line.getOptions()) {
-        System.out.println(
-            "Preparing option " + option.getLongOpt() + " with value " + option.getValuesList());
+        log.info("Preparing option {} with value {}", option.getLongOpt(), option.getValuesList());
         ((VitruvCLIOption) option).prepare(line, configuration);
       }
       generateFiles(configuration);
       for (Option option : line.getOptions()) {
-        System.out.println(
-            "Preprocessing option "
-                + option.getLongOpt()
-                + " with value "
-                + option.getValuesList());
+        log.info("Postprocessing option {} with value {}", option.getLongOpt(), option.getValuesList());
         ((VitruvCLIOption) option).preBuild(line, builder, configuration);
       }
       ProcessBuilder pbuilder;
@@ -86,7 +83,7 @@ public class CLI {
       BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
       String oline;
       while ((oline = reader.readLine()) != null) {
-        System.out.println(oline);
+        log.info(oline);
       }
       process.waitFor();
       if (process.exitValue() != 0) {
@@ -95,18 +92,14 @@ public class CLI {
                 + process.exitValue());
       }
       for (Option option : line.getOptions()) {
-        System.out.println(
-            "Postprocessing option "
-                + option.getLongOpt()
-                + " with value "
-                + option.getValuesList());
+        log.info("Preparing option {} with value {}", option.getLongOpt(), option.getValuesList());
         ((VitruvCLIOption) option).postBuild(line, builder, configuration);
       }
-      System.out.println(builder.buildAndInitialize());
+      log.info(builder.buildAndInitialize().toString());
     } catch (ParseException exp) {
-      System.out.println("Parsing failed.  Reason: " + exp.getMessage());
+      log.error("Parsing failed.  Reason: {}", exp.getMessage());
     } catch (IOException | InterruptedException e) {
-      System.out.println("Invoking maven to build the project failed.  Reason: " + e.getMessage());
+      log.error("Invoking maven to build the project failed.  Reason: {}", e.getMessage());
     }
   }
 
@@ -116,65 +109,65 @@ public class CLI {
     generateFromTemplate.generateRootPom(
         new File((configuration.getLocalPath() + "/pom.xml").replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating root pom");
+    log.info("Generating root pom");
 
     generateFromTemplate.generateConsistencyPom(
         new File((configuration.getLocalPath() + "/consistency/pom.xml").replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating consistency pom");
+    log.info("Generating consistency pom");
 
     generateFromTemplate.generateModelPom(
         new File((configuration.getLocalPath() + "/model/pom.xml").replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating model pom");
+    log.info("Generating model pom");
 
     generateFromTemplate.generateVsumPom(
         new File((configuration.getLocalPath() + "/vsum/pom.xml").replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating vsum pom");
+    log.info("Generating vsum pom");
 
     generateFromTemplate.generateP2WrappersPom(
         new File((configuration.getLocalPath() + "/p2wrappers/pom.xml").replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating p2wrappers pom");
+    log.info("Generating p2wrappers pom");
 
     generateFromTemplate.generateJavaUtilsPom(
         new File(
             (configuration.getLocalPath() + "/p2wrappers/javautils/pom.xml").replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating p2wrappers javautils pom");
+    log.info("Generating p2wrappers javautils pom");
 
     generateFromTemplate.generateXAnnotationsPom(
         new File(
             (configuration.getLocalPath() + "/p2wrappers/activextendannotations/pom.xml")
                 .replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating p2wrappers xannotations pom");
+    log.info("Generating p2wrappers xannotations pom");
 
     generateFromTemplate.generateEMFUtilsPom(
         new File(
             (configuration.getLocalPath() + "/p2wrappers/emfutils/pom.xml").replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating p2wrappers emf utils pom");
+    log.info("Generating p2wrappers emf utils pom");
 
     generateFromTemplate.generateVsumExample(
         new File(
             (configuration.getLocalPath() + "/vsum/src/main/java/VSUMExample.java")
                 .replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating vsum example java class");
+    log.info("Generating vsum example java class");
 
     generateFromTemplate.generateVsumTest(
         new File(
             (configuration.getLocalPath() + "/vsum/src/test/java/VSUMExampleTest.java")
                 .replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating vsum example test java class");
+    log.info("Generating vsum example test java");
 
     generateFromTemplate.generateProjectFile(
         new File((configuration.getLocalPath() + "/model/.project").replaceAll("\\s", "")),
         configuration.getPackageName());
-    System.out.println("Generating project file");
+    log.info("Generating project file");
     File workflow =
         new File(
             (configuration.getLocalPath() + "/model/workflow/generate.mwe2").replaceAll("\\s", ""));

--- a/cli/src/main/java/tools/vitruv/cli/CLI.java
+++ b/cli/src/main/java/tools/vitruv/cli/CLI.java
@@ -62,7 +62,8 @@ public class CLI {
       }
       generateFiles(configuration);
       for (Option option : line.getOptions()) {
-        log.info("Postprocessing option {} with value {}", option.getLongOpt(), option.getValuesList());
+        log.info(
+            "Postprocessing option {} with value {}", option.getLongOpt(), option.getValuesList());
         ((VitruvCLIOption) option).preBuild(line, builder, configuration);
       }
       ProcessBuilder pbuilder;
@@ -97,7 +98,7 @@ public class CLI {
     } catch (IOException | InterruptedException e) {
       log.error("Invoking maven to build the project failed.  Reason: {}", e.getMessage());
     } catch (MissingModelException e) {
-      System.out.println("Generating files failed (missing models).  Reason: " + e.getMessage());
+      log.error("Generating files failed (missing models).  Reason: " + e.getMessage());
     }
   }
 

--- a/cli/src/main/java/tools/vitruv/cli/CLI.java
+++ b/cli/src/main/java/tools/vitruv/cli/CLI.java
@@ -13,6 +13,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+import lombok.extern.slf4j.Slf4j;
 import tools.vitruv.cli.options.ApplyOption;
 import tools.vitruv.cli.configuration.VitruvConfiguration;
 import tools.vitruv.cli.exceptions.MissingModelException;
@@ -30,6 +31,7 @@ import tools.vitruv.framework.vsum.VirtualModelBuilder;
  * parses the command line arguments and triggers the generation of the necessary files and the
  * build of the project.
  */
+@Slf4j
 public class CLI {
 
   /**
@@ -71,15 +73,15 @@ public class CLI {
       runMavenBuild(configuration);
       runPostBuild(line, builder, configuration);
 
-      System.out.println(builder.buildAndInitialize());
+      log.info(builder.buildAndInitialize().toString());
     } catch (ParseException exp) {
-      System.out.println("Parsing failed.  Reason: " + exp.getMessage());
+      log.error("Parsing failed.  Reason: " + exp.getMessage());
     } catch (IllegalArgumentException exp) {
-      System.out.println("Invalid CLI argument or option.  Reason: " + exp.getMessage());
+      log.error("Invalid CLI argument or option.  Reason: " + exp.getMessage());
     } catch (IOException | InterruptedException e) {
-      System.out.println("Invoking maven to build the project failed.  Reason: " + e.getMessage());
+      log.error("Invoking maven to build the project failed.  Reason: " + e.getMessage());
     } catch (MissingModelException e) {
-      System.out.println("Generating files failed (missing models).  Reason: " + e.getMessage());
+      log.error("Generating files failed (missing models).  Reason: " + e.getMessage());
     }
   }
 
@@ -168,7 +170,7 @@ public class CLI {
       return;
     }
 
-    System.out.println(
+    log.info(
         "Preparing option " + option.getLongOpt() + " with value " + formatOptionValues(line, opt));
     option.prepare(line, configuration);
   }
@@ -193,7 +195,7 @@ public class CLI {
   private void runPreBuild(
       CommandLine line, VirtualModelBuilder builder, VitruvConfiguration configuration) {
     for (Option option : line.getOptions()) {
-      System.out.println(
+      log.info(
           "Preprocessing option " + option.getLongOpt() + " with value " + option.getValuesList());
       ((VitruvCLIOption) option).preBuild(line, builder, configuration);
     }
@@ -209,7 +211,7 @@ public class CLI {
   private void runPostBuild(
       CommandLine line, VirtualModelBuilder builder, VitruvConfiguration configuration) {
     for (Option option : line.getOptions()) {
-      System.out.println(
+      log.info(
           "Postprocessing option " + option.getLongOpt() + " with value " + option.getValuesList());
       ((VitruvCLIOption) option).postBuild(line, builder, configuration);
     }
@@ -231,7 +233,7 @@ public class CLI {
         new BufferedReader(new InputStreamReader(process.getInputStream()))) {
       String line;
       while ((line = reader.readLine()) != null) {
-        System.out.println(line);
+        log.info(line);
       }
     }
 
@@ -302,60 +304,60 @@ public class CLI {
     generateFromTemplate.generateRootPom(
         new File((configuration.getLocalPath() + "/pom.xml").trim()),
         configuration.getPackageName());
-    System.out.println("Generating root pom");
+    log.info("Generating root pom");
 
     generateFromTemplate.generateConsistencyPom(
         new File((configuration.getLocalPath() + "/consistency/pom.xml").trim()),
         configuration.getPackageName());
-    System.out.println("Generating consistency pom");
+    log.info("Generating consistency pom");
 
     generateFromTemplate.generateModelPom(
         new File((configuration.getLocalPath() + "/model/pom.xml").trim()),
         configuration.getPackageName());
-    System.out.println("Generating model pom");
+    log.info("Generating model pom");
 
     generateFromTemplate.generateVsumPom(
         new File((configuration.getLocalPath() + "/vsum/pom.xml").trim()),
         configuration.getPackageName());
-    System.out.println("Generating vsum pom");
+    log.info("Generating vsum pom");
 
     generateFromTemplate.generateP2WrappersPom(
         new File((configuration.getLocalPath() + "/p2wrappers/pom.xml").trim()),
         configuration.getPackageName());
-    System.out.println("Generating p2wrappers pom");
+    log.info("Generating p2wrappers pom");
 
     generateFromTemplate.generateJavaUtilsPom(
         new File((configuration.getLocalPath() + "/p2wrappers/javautils/pom.xml").trim()),
         configuration.getPackageName());
-    System.out.println("Generating p2wrappers javautils pom");
+    log.info("Generating p2wrappers javautils pom");
 
     generateFromTemplate.generateXAnnotationsPom(
         new File(
             (configuration.getLocalPath() + "/p2wrappers/activextendannotations/pom.xml").trim()),
         configuration.getPackageName());
-    System.out.println("Generating p2wrappers xannotations pom");
+    log.info("Generating p2wrappers xannotations pom");
 
     generateFromTemplate.generateEMFUtilsPom(
         new File((configuration.getLocalPath() + "/p2wrappers/emfutils/pom.xml").trim()),
         configuration.getPackageName());
-    System.out.println("Generating p2wrappers emf utils pom");
+    log.info("Generating p2wrappers emf utils pom");
 
     generateFromTemplate.generateVsumExample(
         new File((configuration.getLocalPath() + "/vsum/src/main/java/VSUMExample.java").trim()),
         configuration.getPackageName(),
         configuration.getModelNames());
-    System.out.println("Generating vsum example java class");
+    log.info("Generating vsum example java class");
 
     generateFromTemplate.generateVsumTest(
         new File(
             (configuration.getLocalPath() + "/vsum/src/test/java/VSUMExampleTest.java").trim()),
         configuration.getPackageName());
-    System.out.println("Generating vsum example test java class");
+    log.info("Generating vsum example test java class");
 
     generateFromTemplate.generateProjectFile(
         new File((configuration.getLocalPath() + "/model/.project").trim()),
         configuration.getPackageName());
-    System.out.println("Generating project file");
+    log.info("Generating project file");
     File workflow =
         new File((configuration.getLocalPath() + "/model/workflow/generate.mwe2").trim());
     configuration.setWorkflow(workflow);

--- a/cli/src/main/java/tools/vitruv/cli/GenerateFromTemplate.java
+++ b/cli/src/main/java/tools/vitruv/cli/GenerateFromTemplate.java
@@ -8,24 +8,24 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
+import lombok.extern.slf4j.Slf4j;
 import tools.vitruv.cli.configuration.MetamodelLocation;
 import tools.vitruv.cli.configuration.VitruvConfiguration;
 import tools.vitruv.cli.exceptions.MissingModelException;
 import tools.vitruv.cli.options.FileUtils;
 
 /** This class is responsible for generating files from templates. */
+@Slf4j
 public class GenerateFromTemplate {
   /** Constructor. */
   public GenerateFromTemplate() {
   }
 
-  private static final Logger logger = Logger.getLogger(GenerateFromTemplate.class.getName());
   private static final String PACKAGE_NAME = "packageName";
 
   private Configuration getConfiguration() {
@@ -45,7 +45,7 @@ public class GenerateFromTemplate {
     try (Writer fileWriter = new FileWriter(filePath.getAbsolutePath(), false)) {
       template.process(data, fileWriter);
       fileWriter.flush();
-      logger.info("writing to " + filePath.getAbsolutePath());
+      log.info("writing to " + filePath.getAbsolutePath());
     } catch (TemplateException e) {
       e.printStackTrace();
     }

--- a/cli/src/main/java/tools/vitruv/cli/configuration/VitruvConfiguration.java
+++ b/cli/src/main/java/tools/vitruv/cli/configuration/VitruvConfiguration.java
@@ -4,9 +4,9 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.emf.codegen.ecore.genmodel.GenModel;
 import org.eclipse.emf.codegen.ecore.genmodel.GenModelPackage;
 import org.eclipse.emf.common.util.URI;
@@ -17,9 +17,8 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 
 /** The VitruvConfiguration class is used to store the configuration of the Vitruv CLI. */
+@Slf4j
 public class VitruvConfiguration {
-
-  private static final Logger logger = Logger.getLogger(VitruvConfiguration.class.getName());
 
   /**
    * -- SETTER -- Sets the local path of the configuration.
@@ -93,7 +92,7 @@ public class VitruvConfiguration {
         if (!genmodelResource.getContents().isEmpty()
             && genmodelResource.getContents().get(0) instanceof GenModel genModel) {
           String packageString = removeLastSegment(genModel.getModelPluginID());
-          logger.info("--------------------->>>>  " + packageString);
+          log.info("--------------------->>>>  " + packageString);
           this.setPackageName(packageString);
           localModelDirectory = genModel.getModelDirectory();
         }

--- a/cli/src/main/java/tools/vitruv/cli/options/FileUtils.java
+++ b/cli/src/main/java/tools/vitruv/cli/options/FileUtils.java
@@ -9,13 +9,12 @@ import java.nio.file.StandardCopyOption;
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.logging.Logger;
+import lombok.extern.slf4j.Slf4j;
 import tools.vitruv.cli.configuration.CustomClassLoader;
 
 /** The FileUtils class provides utility methods for file operations. */
+@Slf4j
 public final class FileUtils {
-
-  private static final Logger logger = Logger.getLogger(FileUtils.class.getName());
 
   private FileUtils() {}
 
@@ -60,7 +59,7 @@ public final class FileUtils {
     }
     // Files.copy throws a misleading Exception if the target File and/or the
     // folders of the target file are not existing.
-    logger.info("Copying file " + source.getAbsolutePath() + " to  " + target.getAbsolutePath());
+    log.info("Copying file " + source.getAbsolutePath() + " to  " + target.getAbsolutePath());
     target.getParentFile().mkdirs();
     try {
       target.createNewFile();
@@ -86,12 +85,12 @@ public final class FileUtils {
       }
       // Create the file
       if (file.createNewFile()) {
-        logger.info("File created: " + file.getAbsolutePath());
+        log.info("File created: " + file.getAbsolutePath());
       } else {
-        logger.info("File already exists: " + file.getAbsolutePath());
+        log.info("File already exists: " + file.getAbsolutePath());
       }
     } catch (IOException e) {
-      logger.info("An error occurred while creating the file: " + e.getMessage());
+      log.error("An error occurred while creating the file: " + e.getMessage());
       e.printStackTrace();
     }
   }
@@ -107,9 +106,9 @@ public final class FileUtils {
     Path folderPath = path.resolve(folder);
     File file = folderPath.toFile();
     if (file.mkdirs()) {
-      logger.info("Directory created: " + file.getAbsolutePath());
+      log.info("Directory created: " + file.getAbsolutePath());
     } else {
-      logger.info("Directory already exists: " + file.getAbsolutePath());
+      log.info("Directory already exists: " + file.getAbsolutePath());
     }
     return folderPath;
   }
@@ -155,7 +154,7 @@ public final class FileUtils {
         if (entry.getName().endsWith(".class")) {
           // Print the class name
           String className = entry.getName().replace("/", ".").replace(".class", "");
-          logger.info(className);
+          log.info(className);
         }
       }
 

--- a/cli/src/main/java/tools/vitruv/cli/options/GenmodelPrecheckOption.java
+++ b/cli/src/main/java/tools/vitruv/cli/options/GenmodelPrecheckOption.java
@@ -6,11 +6,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Scanner;
 import org.apache.commons.cli.CommandLine;
+import lombok.extern.slf4j.Slf4j;
 import tools.vitruv.cli.configuration.MetamodelLocation;
 import tools.vitruv.cli.configuration.VitruvConfiguration;
 import tools.vitruv.framework.vsum.VirtualModelBuilder;
 
 /** CLI option to inspect and optionally standardize .genmodel files for MWE2 compatibility. */
+@Slf4j
 public class GenmodelPrecheckOption extends VitruvCLIOption {
 
   private static final String OPT = "pg";
@@ -58,7 +60,7 @@ public class GenmodelPrecheckOption extends VitruvCLIOption {
     throwIfFailuresExist(failures);
 
     if (previewIssues.isEmpty()) {
-      System.out.println("No problems found in the provided genmodel files.");
+      log.info("No problems found in the provided genmodel files.");
       return;
     }
 
@@ -132,7 +134,7 @@ public class GenmodelPrecheckOption extends VitruvCLIOption {
    */
   private void handleNoIssues(List<GenmodelPrecheck.Issue> previewIssues) {
     if (previewIssues.isEmpty()) {
-      System.out.println("No problems found in the provided genmodel files.");
+      log.info("No problems found in the provided genmodel files.");
       throw new NoIssuesFoundException();
     }
   }
@@ -143,9 +145,9 @@ public class GenmodelPrecheckOption extends VitruvCLIOption {
    * @param previewIssues the detected issues
    */
   private void printPreviewIssues(List<GenmodelPrecheck.Issue> previewIssues) {
-    System.out.println("We found some problems in your genmodel files:");
+    log.info("We found some problems in your genmodel files:");
     for (GenmodelPrecheck.Issue issue : previewIssues) {
-      System.out.println("- " + issue);
+      log.info("- " + issue);
     }
   }
 
@@ -190,13 +192,13 @@ public class GenmodelPrecheckOption extends VitruvCLIOption {
    */
   private void printAppliedIssues(List<GenmodelPrecheck.Issue> appliedIssues) {
     if (appliedIssues.isEmpty()) {
-      System.out.println("No changes were necessary.");
+      log.info("No changes were necessary.");
       return;
     }
 
-    System.out.println("Applied genmodel changes:");
+    log.info("Applied genmodel changes:");
     for (GenmodelPrecheck.Issue issue : appliedIssues) {
-      System.out.println("- " + issue);
+      log.info("- " + issue);
     }
   }
 
@@ -209,7 +211,7 @@ public class GenmodelPrecheckOption extends VitruvCLIOption {
    * @return {@code true} if the user confirmed the fixes
    */
   public boolean askForFixConfirmation() {
-    System.out.print("Do you want to fix them? [y/N]: ");
+    log.info("Do you want to fix them? [y/N]: ");
     Scanner scanner = new Scanner(System.in);
     String input = scanner.nextLine();
     String normalized = input == null ? "" : input.trim().toLowerCase(Locale.ROOT);

--- a/cli/src/main/java/tools/vitruv/cli/options/MetamodelOption.java
+++ b/cli/src/main/java/tools/vitruv/cli/options/MetamodelOption.java
@@ -18,10 +18,15 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl;
 
+import lombok.extern.slf4j.Slf4j;
 import tools.vitruv.cli.configuration.MetamodelLocation;
 import tools.vitruv.cli.configuration.VitruvConfiguration;
 import tools.vitruv.framework.vsum.VirtualModelBuilder;
 
+/**
+ * CLI option handler for configuring and processing metamodels in the Vitruv framework.
+ */
+@Slf4j
 public class MetamodelOption extends VitruvCLIOption {
   // resource/tools.vitruv.methodologisttemplate.model/src/main/ecore/model.genmodel
   public static final String SUBFOLDER = "/model/src/main/ecore/";
@@ -75,12 +80,12 @@ public class MetamodelOption extends VitruvCLIOption {
     try {
       List<String> alines = Files.readAllLines(configuration.getWorkflow().toPath());
       List<String> lines = new ArrayList<>(alines);
-      System.out.println(configuration.getWorkflow().toPath());
+      log.info(configuration.getWorkflow().toPath().toString());
       for (int i = 0; i < lines.size(); i++) {
         if (lines.get(i).contains("#")) {
-          System.out.println(lines);
+          log.info(lines.get(i));
           lines.set(i, lines.get(i).replace("#", createSpecialString(count, "#")));
-          System.out.println(lines);
+          log.info(lines.get(i));
           Files.write(
               configuration.getWorkflow().toPath(), lines, StandardOpenOption.TRUNCATE_EXISTING);
           return;

--- a/cli/src/main/java/tools/vitruv/cli/options/ReactionOption.java
+++ b/cli/src/main/java/tools/vitruv/cli/options/ReactionOption.java
@@ -4,10 +4,15 @@ import java.io.File;
 
 import org.apache.commons.cli.CommandLine;
 
+import lombok.extern.slf4j.Slf4j;
 import tools.vitruv.change.propagation.ChangePropagationSpecification;
 import tools.vitruv.cli.configuration.VitruvConfiguration;
 import tools.vitruv.framework.vsum.VirtualModelBuilder;
 
+/**
+ * CLI option handler for configuring change propagation reactions in the Vitruv framework.
+ */
+@Slf4j
 public class ReactionOption extends VitruvCLIOption {
 
   private File reactionsFile;
@@ -38,7 +43,7 @@ public class ReactionOption extends VitruvCLIOption {
     ChangePropagationSpecification loadedClass = null;
     try {
       String name = FileUtils.findOption(reactionsFile, "reactions:");
-      System.out.println(
+      log.info(
           name.substring(0, 1).toUpperCase()
               + name.substring(1)
               + "ChangePropagationSpecification");
@@ -62,7 +67,7 @@ public class ReactionOption extends VitruvCLIOption {
                   + "ChangePropagationSpecification")
           .getDeclaredConstructor()
           .newInstance();
-      System.out.println("that works");
+      log.info("that works");
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/cli/src/main/resources/logback.xml
+++ b/cli/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Console Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%logger{0} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Root Logger -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <!-- Application Logger -->
+    <logger name="tools.vitruv.cli" level="INFO"/>
+</configuration>
+

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,11 @@
                 <artifactId>freemarker</artifactId>
                 <version>2.3.31</version>
             </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>1.18.30</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This pull request refactors the Vitruv CLI codebase to standardize logging using SLF4J via Lombok's `@Slf4j` annotation. It replaces all usages of `System.out.println` and `java.util.logging.Logger` with SLF4J logging calls, improving consistency, configurability, and maintainability of log output. Additionally, it updates the build configuration to include the necessary dependencies.

**Logging Standardization and Refactoring:**

* Replaced all `System.out.println` and `java.util.logging.Logger` statements with SLF4J logging calls (`log.info`, `log.error`) across the CLI, configuration, file utilities, and option classes, ensuring consistent logging practices throughout the codebase. [[1]](diffhunk://#diff-781dc2289e43f8656d3c0c8ed8ea3e4f8303fe5e39c8087a74490fe2e51f5f07L74-R84) [[2]](diffhunk://#diff-11865bcb24cc81f66915fd46088f18ca13c9bbfd37fc221456a6c710c2ad4227L48-R48) [[3]](diffhunk://#diff-8ba98ca623b1547661dd74c508384ea78a95d654b49ec767687ec0ad24fc52fbL96-R95) [[4]](diffhunk://#diff-c1262eaf580499d00d489222a38b759e35008cc6a984a0a4424d4cd884318f7cL63-R62) [[5]](diffhunk://#diff-c1262eaf580499d00d489222a38b759e35008cc6a984a0a4424d4cd884318f7cL89-R93) [[6]](diffhunk://#diff-c1262eaf580499d00d489222a38b759e35008cc6a984a0a4424d4cd884318f7cL110-R111) [[7]](diffhunk://#diff-c1262eaf580499d00d489222a38b759e35008cc6a984a0a4424d4cd884318f7cL158-R157) [[8]](diffhunk://#diff-4760cdf3b0c731a98b64d81f3a498a6ac1d0b90008b0c17b6b3eee748a483503L61-R63) [[9]](diffhunk://#diff-4760cdf3b0c731a98b64d81f3a498a6ac1d0b90008b0c17b6b3eee748a483503L135-R137) [[10]](diffhunk://#diff-4760cdf3b0c731a98b64d81f3a498a6ac1d0b90008b0c17b6b3eee748a483503L146-R150) [[11]](diffhunk://#diff-4760cdf3b0c731a98b64d81f3a498a6ac1d0b90008b0c17b6b3eee748a483503L193-R201) [[12]](diffhunk://#diff-4760cdf3b0c731a98b64d81f3a498a6ac1d0b90008b0c17b6b3eee748a483503L212-R214)

* Annotated all main classes with Lombok's `@Slf4j` and removed explicit logger declarations, simplifying logger usage and setup. [[1]](diffhunk://#diff-781dc2289e43f8656d3c0c8ed8ea3e4f8303fe5e39c8087a74490fe2e51f5f07R16) [[2]](diffhunk://#diff-781dc2289e43f8656d3c0c8ed8ea3e4f8303fe5e39c8087a74490fe2e51f5f07R34) [[3]](diffhunk://#diff-11865bcb24cc81f66915fd46088f18ca13c9bbfd37fc221456a6c710c2ad4227L11-L28) [[4]](diffhunk://#diff-8ba98ca623b1547661dd74c508384ea78a95d654b49ec767687ec0ad24fc52fbL7-R9) [[5]](diffhunk://#diff-8ba98ca623b1547661dd74c508384ea78a95d654b49ec767687ec0ad24fc52fbR20-L23) [[6]](diffhunk://#diff-c1262eaf580499d00d489222a38b759e35008cc6a984a0a4424d4cd884318f7cL12-L19) [[7]](diffhunk://#diff-4760cdf3b0c731a98b64d81f3a498a6ac1d0b90008b0c17b6b3eee748a483503R9-R15) [[8]](diffhunk://#diff-f76898371378472c06e211ac50577e776046ee29b73c97f83fa5b27adf29f49eR21-R29)

**Build Configuration Updates:**

* Added `logback-classic` as the SLF4J implementation and `lombok` as a dependency in `cli/pom.xml` to support the new logging approach. [[1]](diffhunk://#diff-14540919135aab6b48f03e8a03ab015774bec6c85717f42c97fe1df242222414R166-R170) [[2]](diffhunk://#diff-14540919135aab6b48f03e8a03ab015774bec6c85717f42c97fe1df242222414R225-R229)

These changes modernize the codebase's logging infrastructure, making it easier to manage log output and integrate with external logging systems.