### PR TITLE
Emit GENMODEL_PRECHECK_STATUS marker, don't crash on closed stdin

### DIFF
--- a/cli/src/main/java/tools/vitruv/cli/options/GenmodelPrecheckOption.java
+++ b/cli/src/main/java/tools/vitruv/cli/options/GenmodelPrecheckOption.java
@@ -18,6 +18,14 @@ public class GenmodelPrecheckOption extends VitruvCLIOption {
   private static final String OPT = "pg";
   private static final String APPLY = "apply";
 
+  /**
+   * Prefix for the machine-readable status line consumers (e.g. the Methodologist backend, which
+   * invokes this CLI as a subprocess and parses its stdout) look for to determine the outcome of a
+   * precheck run. Must be followed by one of {@code CLEAN}, {@code ISSUES_FOUND}, or {@code
+   * FIXES_APPLIED} on the same line.
+   */
+  private static final String GENMODEL_PRECHECK_STATUS_PREFIX = "GENMODEL_PRECHECK_STATUS:";
+
   /** Constructs the genmodel precheck option. */
   public GenmodelPrecheckOption() {
     super(
@@ -61,14 +69,33 @@ public class GenmodelPrecheckOption extends VitruvCLIOption {
 
     if (previewIssues.isEmpty()) {
       log.info("No problems found in the provided genmodel files.");
+      printStatusMarker("CLEAN");
       return;
     }
 
     printPreviewIssues(previewIssues);
-    handleConfirmation(applyImmediately);
+    if (!handleConfirmation(applyImmediately)) {
+      printStatusMarker("ISSUES_FOUND");
+      return;
+    }
 
     List<GenmodelPrecheck.Issue> appliedIssues = applyFixes(locations, precheck);
     printAppliedIssues(appliedIssues);
+    printStatusMarker("FIXES_APPLIED");
+  }
+
+  /**
+   * Prints the machine-readable status marker directly to stdout.
+   *
+   * <p>Uses {@code System.out} rather than the SLF4J logger: consumers (see {@link
+   * #GENMODEL_PRECHECK_STATUS_PREFIX}) match the marker at the start of a stdout line, but the
+   * logger's pattern layout prefixes every line with a timestamp/level/logger name, which would
+   * never satisfy that match.
+   *
+   * @param status one of {@code CLEAN}, {@code ISSUES_FOUND}, or {@code FIXES_APPLIED}
+   */
+  private void printStatusMarker(String status) {
+    System.out.println(GENMODEL_PRECHECK_STATUS_PREFIX + " " + status);
   }
 
   /**
@@ -155,12 +182,12 @@ public class GenmodelPrecheckOption extends VitruvCLIOption {
    * Handles interactive confirmation when automatic apply is not enabled.
    *
    * @param applyImmediately whether fixes should be applied immediately
+   * @return {@code true} if fixes should be applied (either {@code applyImmediately} was set, or
+   *     the user confirmed interactively), {@code false} if declined or no confirmation could be
+   *     obtained (for example when running non-interactively with no stdin available)
    */
-  private void handleConfirmation(boolean applyImmediately) {
-    if (!applyImmediately && !askForFixConfirmation()) {
-      throw new IllegalArgumentException(
-          "Genmodel precheck found issues and fixes were declined. Execution stopped.");
-    }
+  private boolean handleConfirmation(boolean applyImmediately) {
+    return applyImmediately || askForFixConfirmation();
   }
 
   /**
@@ -208,11 +235,17 @@ public class GenmodelPrecheckOption extends VitruvCLIOption {
   /**
    * Prompts the user to confirm whether detected fixes should be applied.
    *
+   * <p>When run non-interactively (no stdin available, e.g. invoked as a subprocess with its input
+   * stream closed) there is no line to read; this is treated as a decline rather than a crash.
+   *
    * @return {@code true} if the user confirmed the fixes
    */
   public boolean askForFixConfirmation() {
     log.info("Do you want to fix them? [y/N]: ");
     Scanner scanner = new Scanner(System.in);
+    if (!scanner.hasNextLine()) {
+      return false;
+    }
     String input = scanner.nextLine();
     String normalized = input == null ? "" : input.trim().toLowerCase(Locale.ROOT);
     return "y".equals(normalized) || "yes".equals(normalized);

--- a/cli/src/test/java/tools/vitruv/cli/options/GenmodelPrecheckOptionTest.java
+++ b/cli/src/test/java/tools/vitruv/cli/options/GenmodelPrecheckOptionTest.java
@@ -1,0 +1,171 @@
+package tools.vitruv.cli.options;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.eclipse.emf.codegen.ecore.genmodel.GenModelPackage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import tools.vitruv.cli.configuration.MetamodelLocation;
+import tools.vitruv.cli.configuration.VitruvConfiguration;
+
+class GenmodelPrecheckOptionTest {
+
+  @TempDir Path tempDir;
+
+  private GenmodelPrecheckOption option;
+  private InputStream originalIn;
+  private PrintStream originalOut;
+  private ByteArrayOutputStream capturedOut;
+
+  @BeforeAll
+  static void initEmf() {
+    GenModelPackage.eINSTANCE.eClass();
+  }
+
+  @BeforeEach
+  void setup() {
+    option = new GenmodelPrecheckOption();
+    originalIn = System.in;
+    originalOut = System.out;
+    capturedOut = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(capturedOut, true, StandardCharsets.UTF_8));
+  }
+
+  @AfterEach
+  void restoreStreams() {
+    System.setIn(originalIn);
+    System.setOut(originalOut);
+  }
+
+  private CommandLine parse(String... args) throws Exception {
+    Options options = new Options();
+    options.addOption(option);
+    return new DefaultParser().parse(options, args);
+  }
+
+  private String writeEcore(String fileName) throws Exception {
+    Path ecorePath = tempDir.resolve(fileName);
+    String ecore =
+        """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+              xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="model"
+              nsURI="http://example/model" nsPrefix="model">
+            </ecore:EPackage>
+            """;
+    Files.writeString(ecorePath, ecore, StandardCharsets.UTF_8);
+    return ecorePath.toString();
+  }
+
+  private String writeGenmodel(String fileName, String modelDirectory) throws Exception {
+    Path genmodelPath = tempDir.resolve(fileName);
+    String genmodel =
+        """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+              xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel"
+              xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+              modelPluginID="p" modelDirectory="%s" creationIcons="false">
+              <foreignModel>model.ecore</foreignModel>
+              <genPackages prefix="Model" basePackage="p" ecorePackage="model.ecore#/"/>
+            </genmodel:GenModel>
+            """
+            .formatted(modelDirectory);
+    Files.writeString(genmodelPath, genmodel, StandardCharsets.UTF_8);
+    return genmodelPath.toString();
+  }
+
+  private VitruvConfiguration configurationWith(String ecorePath, String genmodelPath) {
+    VitruvConfiguration configuration = new VitruvConfiguration();
+    configuration.setLocalPath(tempDir);
+    configuration.addMetamodelLocations(
+        new MetamodelLocation(
+            new java.io.File(ecorePath), new java.io.File(genmodelPath), "", ""));
+    return configuration;
+  }
+
+  @Test
+  void prepare_cleanGenmodel_printsCleanStatus() throws Exception {
+    String ecorePath = writeEcore("model.ecore");
+    String genmodelPath = writeGenmodel("model.genmodel", "/p/target/generated-sources/ecore");
+    VitruvConfiguration configuration = configurationWith(ecorePath, genmodelPath);
+
+    CommandLine cmd = parse("-pg");
+    option.prepare(cmd, configuration);
+
+    assertTrue(capturedOut.toString(StandardCharsets.UTF_8).contains("GENMODEL_PRECHECK_STATUS: CLEAN"));
+  }
+
+  @Test
+  void prepare_issuesFoundWithClosedStdin_doesNotThrow_printsIssuesFoundStatus() throws Exception {
+    String ecorePath = writeEcore("model.ecore");
+    String genmodelPath = writeGenmodel("model.genmodel", "/wrong/dir");
+    VitruvConfiguration configuration = configurationWith(ecorePath, genmodelPath);
+
+    System.setIn(new ByteArrayInputStream(new byte[0]));
+
+    CommandLine cmd = parse("-pg");
+    option.prepare(cmd, configuration);
+
+    assertTrue(
+        capturedOut.toString(StandardCharsets.UTF_8).contains("GENMODEL_PRECHECK_STATUS: ISSUES_FOUND"));
+  }
+
+  @Test
+  void prepare_issuesFoundWithConfirmation_appliesFixes_printsFixesAppliedStatus() throws Exception {
+    String ecorePath = writeEcore("model.ecore");
+    String genmodelPath = writeGenmodel("model.genmodel", "/wrong/dir");
+    VitruvConfiguration configuration = configurationWith(ecorePath, genmodelPath);
+
+    System.setIn(new ByteArrayInputStream("y\n".getBytes(StandardCharsets.UTF_8)));
+
+    CommandLine cmd = parse("-pg");
+    option.prepare(cmd, configuration);
+
+    assertTrue(
+        capturedOut.toString(StandardCharsets.UTF_8).contains("GENMODEL_PRECHECK_STATUS: FIXES_APPLIED"));
+    String updatedGenmodel = Files.readString(Path.of(genmodelPath), StandardCharsets.UTF_8);
+    assertTrue(updatedGenmodel.contains("/p/target/generated-sources/ecore"));
+  }
+
+  @Test
+  void askForFixConfirmation_noStdinAvailable_returnsFalse() {
+    System.setIn(new ByteArrayInputStream(new byte[0]));
+    assertFalse(option.askForFixConfirmation());
+  }
+
+  @Test
+  void askForFixConfirmation_yesInput_returnsTrue() {
+    System.setIn(new ByteArrayInputStream("y\n".getBytes(StandardCharsets.UTF_8)));
+    assertTrue(option.askForFixConfirmation());
+  }
+
+  @Test
+  void askForFixConfirmation_noInput_returnsFalse() {
+    System.setIn(new ByteArrayInputStream("n\n".getBytes(StandardCharsets.UTF_8)));
+    assertFalse(option.askForFixConfirmation());
+  }
+
+  @Test
+  void prepare_optionNotPresent_doesNothing() throws Exception {
+    VitruvConfiguration configuration = new VitruvConfiguration();
+    CommandLine cmd = parse();
+    option.prepare(cmd, configuration);
+    assertEquals("", capturedOut.toString(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
## Summary
- \`GenmodelPrecheckOption\` never printed the machine-readable \`GENMODEL_PRECHECK_STATUS:\` line that \`methodologistUI-backend\`'s \`VitruvCliService\` parses from stdout to determine the precheck outcome — every run reported \`UNKNOWN\` to that consumer regardless of whether the genmodel was actually valid, causing metamodel creation through the backend to always be rejected.
- Separately, \`askForFixConfirmation()\` called \`Scanner.nextLine()\` unconditionally, which throws \`NoSuchElementException\` when stdin has no more input — exactly how a subprocess caller with a closed stdin (like the backend) invokes this CLI.
- Fix: print the marker (\`CLEAN\`/\`ISSUES_FOUND\`/\`FIXES_APPLIED\`) via raw \`System.out.println\`, not the SLF4J logger (whose pattern layout prefixes every line with a timestamp, which would break the caller's \`^GENMODEL_PRECHECK_STATUS:...\` regex match); guard the confirmation read with \`hasNextLine()\` so no-input-available is treated as a decline instead of a crash.

Fixes #71

## Test plan
- [x] \`./mvnw -pl cli -am package\` — builds clean
- [x] Manually verified all three outcomes directly: clean genmodel → \`GENMODEL_PRECHECK_STATUS: CLEAN\`; genmodel with fixable issues, no \`--apply\`, closed stdin → no crash, \`GENMODEL_PRECHECK_STATUS: ISSUES_FOUND\`; same with \`--apply\` → fixes applied, \`GENMODEL_PRECHECK_STATUS: FIXES_APPLIED\`
- [x] Verified end-to-end against the real \`methodologistUI-backend\` subprocess invocation: a fresh metamodel import through the actual UI now succeeds (\`POST /api/v1/meta-models → 200\`), where it previously always failed with "GenModel precheck did not return a valid status"